### PR TITLE
Add Disabling of IMDSv1 to Default Security Baseline

### DIFF
--- a/new-baseline/enforce-s3-tls.yaml
+++ b/new-baseline/enforce-s3-tls.yaml
@@ -1,3 +1,12 @@
+#############################
+# Title: Enforce-S3-TLS
+# Purpose: This cfn creates a lambda function that is invoked on a hourly basis. 
+# The Lambda function queries all s3 buckets and checks if the bucket policy enforces TLS.  If there is no policy, it creates a policy with the required statement.  
+# If there is a policy, it checks all statements to see if there is a statement that enforces ssl.  If there is not one, it inserts the required statement.
+# Author: Matthew Venne
+# Company: stackArmor
+# July 9, 2021
+##############################
 Resources:
   riamRole:
     Type: AWS::IAM::Role

--- a/new-baseline/enforce-s3-tls.yaml
+++ b/new-baseline/enforce-s3-tls.yaml
@@ -1,0 +1,99 @@
+Resources:
+  riamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: Enforce-S3-TLS-Lambda-Role
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - 
+         PolicyName: "UpdateS3Policy"
+         PolicyDocument:
+           Version: "2012-10-17"
+           Statement:
+              - 
+                Effect: "Allow"
+                Action: 
+                - s3:ListAllMyBuckets
+                - s3:PutBucketPolicy
+                - s3:GetBucketPolicy
+                Resource: "*"
+      ManagedPolicyArns:
+      - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  rlambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: Enforce_S3_TLS
+      Handler: index.lambda_handler
+      MemorySize: 512
+      Role: !GetAtt riamRole.Arn
+      Runtime:  python3.8
+      Timeout: 600
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import os
+
+          s3= boto3.client('s3')
+          s3_resource = boto3.resource('s3')
+          buckets=s3.list_buckets()['Buckets']
+
+          region=os.environ['AWS_REGION']
+
+          if "gov" in region:
+              partition='aws-us-gov'
+          else:
+              partition='aws'
+
+          def lambda_handler(event, context):
+
+              for bucket in buckets:
+                  try:
+                      policy=s3.get_bucket_policy(Bucket=bucket['Name'])['Policy']
+                      statements=json.loads(policy)['Statement']
+                      enforcessl={"Action": "s3:*","Effect": "Deny","Resource": ["arn:aws:s3:::bucket-name", "arn:aws:s3:::bucket_name/*"],"Condition": {"Bool": {"aws:SecureTransport": "false"}},"Principal": "*"}
+                      enforcessl['Resource']=['arn:' + partition + ':s3:::' + bucket['Name'],'arn:' + partition + ':s3:::' + bucket['Name']+'/*']
+                      if 'Deny' in [statement['Effect'] for statement in statements] and 'false' in [statement['Condition']['Bool']['aws:SecureTransport'] for statement in statements] and '*' in [statement['Principal'] for statement in statements]:
+                          policy=json.loads(policy)
+                          policy['Statement'].append(enforcessl)
+                          print(bucket['Name'])
+                          s3.put_bucket_policy(
+                              Bucket=bucket['Name'],
+                              Policy=json.dumps(policy))
+                      else:
+                          print("already ssl")
+                  except:
+                      enforcessl={"Id": "BucketPolicy", "Version": "2012-10-17", "Statement": [{"Sid": "EnforceTLS","Action": "s3:*","Effect": "Deny","Resource": ["arn:aws:s3:::bucket-name", "arn:aws:s3:::bucket_name/*"],"Condition": {"Bool": {"aws:SecureTransport": "false"}},"Principal": "*"}]}
+                      enforcessl['Statement'][0]['Resource']=['arn:' + partition + ':s3:::' + bucket['Name'],'arn:' + partition + ':s3:::' + bucket['Name']+'/*']
+                      response = s3.put_bucket_policy(
+                          Bucket=bucket['Name'],
+                          Policy=json.dumps(enforcessl)
+                      )
+  CWRule:
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "HourlyLambdaRule"
+      ScheduleExpression: "rate(1 hour)"
+      State: "ENABLED"
+      Targets: 
+        - 
+          Arn: 
+            Fn::GetAtt: 
+              - "rlambdaFunction"
+              - "Arn"
+          Id: "TargetFunctionV1"
+  LambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Principal: events.amazonaws.com
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref rlambdaFunction
+      SourceArn: !GetAtt CWRule.Arn

--- a/new-baseline/instancemetadataremediation.yaml
+++ b/new-baseline/instancemetadataremediation.yaml
@@ -1,0 +1,89 @@
+Resources:
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: InstanceMetadataLambdaRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: EC2_Access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - ec2:DescribeInstances
+                  - ec2:ModifyInstanceMetadataOptions
+                Resource: '*'
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  InstanceMetadataLambda:
+    Type: AWS::Lambda::Function
+    Properties: 
+      Runtime: python3.8
+      Handler: index.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      Code: 
+        ZipFile: |
+          import json
+          import boto3
+
+          ec2 = boto3.client('ec2')
+          imds_hops_key='IMDS-Hops'
+          key_to_find='EnableIMDSv1'
+
+          def lambda_handler(event, context):
+              instances = ec2.describe_instances()
+              for reservation in instances['Reservations']:
+                  for instance in reservation['Instances']:
+                      if key_to_find not in [tag['Key'] for tag in instance['Tags']]:
+                          if imds_hops_key not in [tag['Key'] for tag in instance['Tags']]:
+                              if instance['MetadataOptions']['HttpTokens']=='optional':
+                                  print('Metadata v1 disabled on ' +instance['InstanceId'] +'Hops limit set to default value of 1')
+                                  ec2.modify_instance_metadata_options(
+                                      InstanceId=instance['InstanceId'],
+                                      HttpTokens='required',
+                                      HttpPutResponseHopLimit=1,
+                                      HttpEndpoint='enabled'
+                                      )
+                          elif imds_hops_key in [tag['Key'] for tag in instance['Tags']]:
+                              for tag in instance['Tags']:
+                                  if tag['Key']==imds_hops_key:
+                                      hops=tag['Value']
+                              if instance['MetadataOptions']['HttpTokens']=='optional' and instance['MetadataOptions']['HttpPutResponseHopLimit']!=hops:   
+                                  print('Metadata v1 disabled on ' +instance['InstanceId']+' Hops limit set to value in tag')
+                                  ec2.modify_instance_metadata_options(
+                                  InstanceId=instance['InstanceId'],
+                                  HttpTokens='required',
+                                  HttpPutResponseHopLimit=int(hops),
+                                  HttpEndpoint='enabled'
+                                  )
+
+  LambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Principal: events.amazonaws.com
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref InstanceMetadataLambda
+      SourceArn: !GetAtt CWRule.Arn
+  CWRule:
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "InstanceMetadataLambdaRule"
+      ScheduleExpression: "rate(1 hour)"
+      State: "ENABLED"
+      Targets: 
+        - 
+          Arn: 
+            Fn::GetAtt: 
+              - "InstanceMetadataLambda"
+              - "Arn"
+          Id: "TargetFunctionV1"
+

--- a/new-baseline/instancemetadataremediation.yaml
+++ b/new-baseline/instancemetadataremediation.yaml
@@ -1,3 +1,13 @@
+#############################
+# Title: InstanceMetadataRemediation
+# Purpose: This cfn creates a lambda function that is invoked on a hourly basis. 
+# The Lambda function queries all ec2 instances that are not enforcing IMDSv2 (http-token = required).
+# It then loops thru and sets IMDS-Hops limit to the value in IMDS-Hops tag or to 1 if the tag does not exist.
+# It will omit instances with the tag 'EnableIMDSv1' if that is required for proper functionality.
+# Author: Matthew Venne
+# Company: stackArmor
+# July 9, 2021
+##############################
 Resources:
   LambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
This contains a stackset to disable IMDSv1 for all instances without a specific tag (when IMDSv1 is required) with the ability to check the tag on an instance to set the requisite # of hops. The lambda is invoked hourly via CW events.



*Description of changes:*
let me know know the proper place to submit this code either here when we set up our next sync. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
